### PR TITLE
fix temp folder cleanup in deploy command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.idea
 /dist
 *.log
 .DS_Store
+nagini.iml

--- a/src/nagini/client/command/NaginiCommandDeploy.java
+++ b/src/nagini/client/command/NaginiCommandDeploy.java
@@ -154,8 +154,8 @@ public class NaginiCommandDeploy extends AbstractCommand {
 
                 // fetch application packet
                 NaginiProcessUtils.command(Arrays.asList(naginiClient.config.client.appFetchCommand.split("\\s* \\s*")),
-                        new File(naginiClient.config.client.basePath),
-                        System.out);
+                                           new File(naginiClient.config.client.basePath),
+                                           System.out);
             }
 
             // compile application jars
@@ -174,6 +174,9 @@ public class NaginiCommandDeploy extends AbstractCommand {
             // send application to remote servers
             naginiClient.fileOps.putAllHosts(tempApplicationPath,
                                              naginiClient.config.server.basePath);
+
+            // clean up temp folders
+            NaginiFileUtils.delete(tempApplicationPath);
         }
     }
 


### PR DESCRIPTION
@FelixGV 
Hi Felix,

This is a minor fix for your previous commit - the temp folder should still be removed while the app folder remains.

Thanks,
Xu Ha
